### PR TITLE
Fix a heap buffer overflow vulnerability in Path::makeCanonical()

### DIFF
--- a/a_util/filesystem/path.cpp
+++ b/a_util/filesystem/path.cpp
@@ -454,7 +454,7 @@ Path& Path::makeCanonical()
                             end = cur;
                             break;
                         }
-                        else if (c == '.' && cur - 1 >= 0 && _impl->path[cur - 1] == '.')
+                        else if (c == '.' && cur >= 1 && _impl->path[cur - 1] == '.')
                         {
                             // we need to take care about more '..'
                             parts_to_skip++;


### PR DESCRIPTION
The `Path::makeCanonical()` has a heap buffer flow vulnerability. An example of a concrete input that triggers this bug is initializing a `Path` object with the following string `................` and then calling the method. The `cur` variable is decremented by `2` in each iteration and when the `if` statement is evaluated when the variable reaches `0`, the check `cur - 1 >= 0` is `true` since `cur` is of type `std::string::size_type` which means is always positive. This means that `0 - 1` is the maximum possible value and then the next array access `_impl->path[cur - 1]` reads from an index outside the boundary of the allocated buffer. This bug was found by fuzzing this API using CI Fuzz from [code intelligence](https://www.code-intelligence.com/).