### PR TITLE
Release 5.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,33 @@
 cmake_minimum_required(VERSION 3.10.0)
 
-# Since CMAKE_CXX_COMPILER_ID is not available before project()
-# we cannot determine the required CMAKE_CXX_STANDARD automatically.
-# CMAKE_CXX_STANDARD needs to be set from outside, e.g. from a conan recipe
+# Start project() now, since any include checks will use the correct compiler flags
+project(a_util_library VERSION 5.6.1)
 
 # Disable extensions here and require the chosen CMAKE_CXX_STANDARD
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 11)
 
-# Start project() now, since any include checks will use the correct compiler flags
-project(a_util_library VERSION 5.6.0)
+# Use conan if available
+if(CONAN_COMPILER)
+    if ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+    		include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
+    	elseif ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo.cmake)
+    		include(${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo.cmake)
+    	elseif ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo_multi.cmake)
+    		include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo_multi.cmake)
+    	elseif ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo_multi.cmake)
+    		include(${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo_multi.cmake)
+    	else()
+    		message(FATAL_ERROR "Conan build info can't be found.")
+    	endif()
+
+    	if(CORTEX_WORKSPACE)
+    		conan_basic_setup(TARGETS)
+    	else()
+    		conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
+    	endif()
+endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 ##check for default install prefix and cmake build type
@@ -39,26 +56,6 @@ option(a_util_cmake_enable_integrated_tests
 if(a_util_cmake_enable_integrated_tests)
     # Generator expressions take 0 as FALSE/OFF and 1 as TRUE/ON
     set(a_util_cmake_enable_integrated_tests 1 CACHE BOOL "" FORCE)
-    # Use conan if available
-    if(CONAN_COMPILER)
-        if ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
-			include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
-		elseif ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo.cmake)
-			include(${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo.cmake)
-		elseif ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo_multi.cmake)
-			include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo_multi.cmake)
-		elseif ( EXISTS ${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo_multi.cmake)
-			include(${CMAKE_CURRENT_BINARY_DIR}/../conanbuildinfo_multi.cmake)
-		else()
-			message(FATAL_ERROR "Conan build info can't be found.")
-		endif()
-
-		if(CORTEX_WORKSPACE)
-			conan_basic_setup(TARGETS)
-		else()
-			conan_basic_setup(TARGETS NO_OUTPUT_DIRS)
-		endif()
-    endif()
 
     #ignore find_package calls inside the source tree from a_util components
     macro(find_package)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ The libraries are currently built and tested using the following compilers and o
 - Use CMakeLists.txt within the main directory as source directory
 - Do not forget to set `CMAKE_INSTALL_PREFIX`
 - Build and install for Debug and RelWithDebInfo
+- Command line for e.g. Windows
+> cmake <source directory> -H<source directory> -B<build directory> -G "Visual Studio 15 2017 Win64" -T v140 -DCMAKE_INSTALL_PREFIX=<install directory> -Da_util_cmake_enable_integrated_tests=ON -DGTEST_DIR=<GTest directory> -DGTEST_LIBRARY=<GTest directory>/lib/gtest.lib -DGTEST_INCLUDE_DIR=<GTest directory>/include -DGTEST_MAIN_LIBRARY=<GTest directory>/lib/gtest_main.lib -DDOXYGEN_EXECUTABLE=<doxygen binary directory>/doxygen.exe -DDOXYGEN_DOT_EXECUTABLE=<graphviz binary directory>/dot.exe
+
 
 #### Optional requirements 
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ The libraries are currently built and tested using the following compilers and o
 - Use CMakeLists.txt within the main directory as source directory
 - Do not forget to set `CMAKE_INSTALL_PREFIX`
 - Build and install for Debug and RelWithDebInfo
-- Command line for e.g. Windows
-> cmake <source directory> -H<source directory> -B<build directory> -G "Visual Studio 15 2017 Win64" -T v140 -DCMAKE_INSTALL_PREFIX=<install directory> -Da_util_cmake_enable_integrated_tests=ON -DGTEST_DIR=<GTest directory> -DGTEST_LIBRARY=<GTest directory>/lib/gtest.lib -DGTEST_INCLUDE_DIR=<GTest directory>/include -DGTEST_MAIN_LIBRARY=<GTest directory>/lib/gtest_main.lib -DDOXYGEN_EXECUTABLE=<doxygen binary directory>/doxygen.exe -DDOXYGEN_DOT_EXECUTABLE=<graphviz binary directory>/dot.exe
+- Command line for e.g. Windows Visual Studio 2017 vc140
+> cmake -H<source directory> -B<build directory> -G "Visual Studio 15 2017 Win64" -T v140 -DCMAKE_INSTALL_PREFIX=<install directory> -Da_util_cmake_enable_integrated_tests=ON -DGTEST_LIBRARY=<GTest directory>/lib/gtest.lib -DGTEST_INCLUDE_DIR=<GTest directory>/include -DGTEST_MAIN_LIBRARY=<GTest directory>/lib/gtest_main.lib -DDOXYGEN_EXECUTABLE=<doxygen binary directory>/doxygen.exe -DDOXYGEN_DOT_EXECUTABLE=<graphviz binary directory>/dot.exe
 
 
 #### Optional requirements 

--- a/a_util/base/CMakeLists.txt
+++ b/a_util/base/CMakeLists.txt
@@ -9,6 +9,8 @@ target_include_directories(a_util_base
            $<INSTALL_INTERFACE:include>
 )
 
+target_compile_features(a_util_base INTERFACE cxx_std_11)
+
 install(TARGETS a_util_base
         EXPORT a_util_base
         ARCHIVE DESTINATION lib

--- a/a_util/base/test/CMakeLists.txt
+++ b/a_util/base/test/CMakeLists.txt
@@ -5,3 +5,12 @@ add_executable(delegate_tests delegate_test.cpp)
 target_link_libraries(delegate_tests PRIVATE GTest::Main a_util_base)
 add_test(delegate_tests delegate_tests)
 set_target_properties(delegate_tests PROPERTIES FOLDER a_util/test/base)
+
+#maybe_unused test
+add_executable(maybe_unused_tests maybe_unused_test.cpp)
+target_link_libraries(maybe_unused_tests PRIVATE GTest::Main a_util_base)
+add_test(maybe_unused_tests maybe_unused_tests)
+set_target_properties(maybe_unused_tests PROPERTIES FOLDER a_util/test/base)
+
+target_compile_options(maybe_unused_tests PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/WX>)
+target_compile_options(maybe_unused_tests PRIVATE $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Werror>)

--- a/a_util/base/test/maybe_unused_test.cpp
+++ b/a_util/base/test/maybe_unused_test.cpp
@@ -1,0 +1,47 @@
+/**
+ * @file
+ * Test a_util::maybe_unused function template
+ *
+ * @copyright
+ * @verbatim
+   Copyright @ 2017 Audi Electronics Venture GmbH. All rights reserved.
+
+       This Source Code Form is subject to the terms of the Mozilla
+       Public License, v. 2.0. If a copy of the MPL was not distributed
+       with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+   If it is not possible or desirable to put the notice in a particular file, then
+   You may include the notice in a location (such as a LICENSE file in a
+   relevant directory) where a recipient would be likely to look for such a notice.
+
+   You may add additional accurate notices of copyright ownership.
+   @endverbatim
+*/
+
+#include "gtest/gtest.h"
+#include "a_util/base/types.h"
+
+class MaybeUnused : public ::testing::Test
+{
+protected:
+    bool faultyCompareWithUnreferencedFormalParameter(int left, int right) noexcept
+    {
+        using a_util::maybe_unused;
+        maybe_unused(right);
+        return left == left;
+    }
+
+    bool faultyCompareWithLocalVariableIsInitializedButNotReferenced(int left, int right) noexcept
+    {
+        using a_util::maybe_unused;
+        bool val = (left == right);
+        maybe_unused(val);
+        return true;
+    }
+};
+
+TEST_F(MaybeUnused, silencesCompilerWarnings)
+{
+    EXPECT_TRUE(faultyCompareWithUnreferencedFormalParameter(42, 43));
+    EXPECT_TRUE(faultyCompareWithLocalVariableIsInitializedButNotReferenced(42, 43));
+}

--- a/a_util/base/types.h
+++ b/a_util/base/types.h
@@ -38,4 +38,16 @@ typedef std::atomic_int_fast64_t atomic_timestamp_t;
 typedef std::atomic<timestamp_t> atomic_timestamp_t;
 #endif
 
+namespace a_util
+{
+
+/**
+ * Mimics C++17 attribute @c maybe_unused to silence compiler warns on potentially unused enitities
+ * @tparam T Type of the potentially unused entity
+ */
+template<typename T>
+void maybe_unused(T&&) {}
+
+}
+
 #endif /* A_UTIL_UTIL_BASE_TYPES_H */

--- a/a_util/datetime/CMakeLists.txt
+++ b/a_util/datetime/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(a_util_datetime
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_datetime a_util_base a_util_strings a_util_memory a_util_regex)
+target_link_libraries(a_util_datetime PUBLIC a_util_base a_util_strings a_util_memory a_util_regex)
 
 set_target_properties(a_util_datetime PROPERTIES FOLDER a_util)
 

--- a/a_util/filesystem/CMakeLists.txt
+++ b/a_util/filesystem/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(a_util_filesystem
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_filesystem a_util_base a_util_strings a_util_memory)
+target_link_libraries(a_util_filesystem PUBLIC a_util_base a_util_strings a_util_memory)
 
 set_target_properties(a_util_filesystem PROPERTIES FOLDER a_util)
 

--- a/a_util/memory/CMakeLists.txt
+++ b/a_util/memory/CMakeLists.txt
@@ -21,7 +21,7 @@ target_include_directories(a_util_memory PUBLIC
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                            $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_memory a_util_base a_util_concurrency)
+target_link_libraries(a_util_memory PUBLIC a_util_base a_util_concurrency)
 
 set_target_properties(a_util_memory PROPERTIES FOLDER a_util)
 

--- a/a_util/parser/CMakeLists.txt
+++ b/a_util/parser/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(a_util_csv_reader
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_csv_reader a_util_base)
+target_link_libraries(a_util_csv_reader PUBLIC a_util_base)
 
 set_target_properties(a_util_csv_reader PROPERTIES FOLDER a_util)
 

--- a/a_util/regex/CMakeLists.txt
+++ b/a_util/regex/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(a_util_regex
     PRIVATE ${PCRE_CUSTOM_BINARY_DIR} ${PCRE_DIR}
 )
 
-target_link_libraries(a_util_regex a_util_base a_util_memory)
+target_link_libraries(a_util_regex PUBLIC a_util_base a_util_memory)
 
 set_target_properties(a_util_regex PROPERTIES FOLDER a_util)
 

--- a/a_util/result/CMakeLists.txt
+++ b/a_util/result/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(a_util_result
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_result a_util_base a_util_concurrency a_util_strings)
+target_link_libraries(a_util_result PUBLIC a_util_base a_util_concurrency a_util_strings)
 
 set_target_properties(a_util_result PROPERTIES FOLDER a_util)
 

--- a/a_util/result/detail/result_info_impl.h
+++ b/a_util/result/detail/result_info_impl.h
@@ -21,6 +21,7 @@
 #ifndef A_UTIL_UTIL_RESULT_DETAIL_RESULT_INFO_IMPL_HEADER_INCLUDED
 #define A_UTIL_UTIL_RESULT_DETAIL_RESULT_INFO_IMPL_HEADER_INCLUDED
 
+#include "a_util/base/types.h"
 #include "a_util/result/result_info_decl.h"
 
 namespace a_util
@@ -65,6 +66,8 @@ inline const char* ResultInfo<void>::getLabel()
 template <typename ResultTypeLHS, typename ResultTypeRHS>
 inline bool operator==(const ResultInfo<ResultTypeLHS>& lhs, const ResultInfo<ResultTypeRHS>& rhs)
 {
+    a_util::maybe_unused(lhs);
+    a_util::maybe_unused(rhs);
     return (lhs.getCode() == rhs.getCode()) && (lhs.getLabel() == rhs.getLabel());
 }
 

--- a/a_util/result/detail/result_type_impl.h
+++ b/a_util/result/detail/result_type_impl.h
@@ -22,6 +22,7 @@
 #define A_UTIL_UTIL_RESULT_DETAIL_RESULT_TYPE_IMPL_HEADER_INCLUDED
 
 #include <utility> //std::swap
+#include "a_util/base/types.h"  //a_util::maybe_unused
 #include "a_util/result/result_info.h"
 #include "a_util/result/detail/result_description_decl.h"
 #include "a_util/result/detail/result_description_impl.h"
@@ -49,6 +50,7 @@ template <typename ErrorType>
 inline Result::Result(const ResultInfo<ErrorType>& error)
     : _result_handle(DescriptionType::makeResultDescription(error.getCode()))
 {
+    a_util::maybe_unused(error);    // C4100
 }
 
 template <typename ErrorType>
@@ -59,6 +61,7 @@ inline Result::Result(ResultInfo<ErrorType> error,
                       const char* function)
     : _result_handle()
 {
+    a_util::maybe_unused(error);    // C4100
     *this = Result(error.getCode(),
                    error_description,
                    line,

--- a/a_util/result/result_info_decl.h
+++ b/a_util/result/result_info_decl.h
@@ -43,7 +43,8 @@
         }                                                                                          \
     };                                                                                             \
     const ::a_util::result::ResultInfo<ResultType_##_label> _label = ResultType_##_label();        \
-    }
+    }                                                                                              \
+    static_assert(sizeof(ResultType_##_label) == 1, "Empty base optimization does not kick in?")
 
 namespace a_util
 {

--- a/a_util/result/test/CMakeLists.txt
+++ b/a_util/result/test/CMakeLists.txt
@@ -35,6 +35,6 @@ target_include_directories(ref_counted_object_test
                            PRIVATE $<IF:${a_util_cmake_enable_integrated_tests},
                                         ${PROJECT_SOURCE_DIR},
                                         ${PROJECT_SOURCE_DIR}/..>)
-target_link_libraries(ref_counted_object_test PRIVATE GTest::Main)
+target_link_libraries(ref_counted_object_test PRIVATE GTest::Main a_util_base)
 add_test(ref_counted_object_test ref_counted_object_test)
 set_target_properties(ref_counted_object_test PROPERTIES FOLDER a_util/test/result)

--- a/a_util/result/test/error_def_test.cpp
+++ b/a_util/result/test/error_def_test.cpp
@@ -21,7 +21,7 @@
 #include "gtest/gtest.h"
 #include "a_util/result/error_def.h"
 
-_MAKE_RESULT(666, TEST_ERROR)
+_MAKE_RESULT(666, TEST_ERROR);
 
 a_util::result::Result makeErrorAndGetFunctionName(std::string& function_name)
 {

--- a/a_util/result/test/ref_counted_object_test.cpp
+++ b/a_util/result/test/ref_counted_object_test.cpp
@@ -51,22 +51,22 @@ struct ReferencedObject : public ReferencedObjectInterface
     ReferencedObject& operator=(ReferencedObject&&) = delete;
 
     // tests std:forward
-    ReferencedObject(int max_instances) : max_instances(max_instances)
+    ReferencedObject(int max_instances) : _max_instances(max_instances)
     {
     }
 
     // tests const correct access via ref counter
     void setContent(int max_instances) override
     {
-        this->max_instances = max_instances;
+        this->_max_instances = max_instances;
     }
     int getContent() const override
     {
-        return this->max_instances;
+        return this->_max_instances;
     }
 
 private:
-    int max_instances;
+    int _max_instances;
 };
 
 /****************************** TEST *****************************/

--- a/a_util/result/test/result_type_test.cpp
+++ b/a_util/result/test/result_type_test.cpp
@@ -32,21 +32,21 @@
 /// Create the default success code which must be equal to global a_util::result::SUCCESS
 _MAKE_RESULT(0, SUCCESS);
 /// Create error type ERR_INVALID_ARG with numeric representation -5
-_MAKE_RESULT(-5, ERR_INVALID_ARG)
+_MAKE_RESULT(-5, ERR_INVALID_ARG);
 /// Create error type ERR_INVALID_ADDRESS with numeric representation -7
-_MAKE_RESULT(-7, ERR_INVALID_ADDRESS)
+_MAKE_RESULT(-7, ERR_INVALID_ADDRESS);
 /// Create error type ERR_MEMORY with numeric representation -12
-_MAKE_RESULT(-12, ERR_MEMORY)
+_MAKE_RESULT(-12, ERR_MEMORY);
 /// Create error type ERR_TIMEOUT with numeric representation -13
-_MAKE_RESULT(-13, ERR_TIMEOUT)
+_MAKE_RESULT(-13, ERR_TIMEOUT);
 /// Create error type ERR_NOT_SUPPORTED with numeric representation -19
-_MAKE_RESULT(-19, ERR_NOT_SUPPORTED)
+_MAKE_RESULT(-19, ERR_NOT_SUPPORTED);
 /// Create error type ERR_NOT_FOUND with numeric representation -20
-_MAKE_RESULT(-20, ERR_NOT_FOUND)
+_MAKE_RESULT(-20, ERR_NOT_FOUND);
 /// Create error type ERR_NOT_INITIALIZED with numeric representation -37
-_MAKE_RESULT(-37, ERR_NOT_INITIALIZED)
+_MAKE_RESULT(-37, ERR_NOT_INITIALIZED);
 /// Create error type ERR_FAILED with numeric representation -38
-_MAKE_RESULT(-38, ERR_FAILED)
+_MAKE_RESULT(-38, ERR_FAILED);
 
 using a_util::result::isFailed;
 using a_util::result::isOk;

--- a/a_util/strings/CMakeLists.txt
+++ b/a_util/strings/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(a_util_strings
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_strings a_util_base)
+target_link_libraries(a_util_strings PUBLIC a_util_base)
 
 set_target_properties(a_util_strings PROPERTIES FOLDER a_util)
 

--- a/a_util/variant/CMakeLists.txt
+++ b/a_util/variant/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(a_util_variant
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
                                   $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(a_util_variant a_util_base a_util_strings a_util_memory)
+target_link_libraries(a_util_variant PUBLIC a_util_base a_util_strings a_util_memory)
 
 set_target_properties(a_util_variant PROPERTIES FOLDER a_util)
 

--- a/a_util/xml/CMakeLists.txt
+++ b/a_util/xml/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(a_util_xml
                                   $<INSTALL_INTERFACE:include>
                            PRIVATE ${PUGI_DIR}/src)
                            
-target_link_libraries(a_util_xml a_util_base)
+target_link_libraries(a_util_xml PUBLIC a_util_base)
 
 set_target_properties(a_util_xml PROPERTIES FOLDER a_util)
 

--- a/a_util/xml/dom.h
+++ b/a_util/xml/dom.h
@@ -168,47 +168,45 @@ public:
      */
     bool eraseAttribute(const std::string& name);
 
-    /**
-     * Finds a node based on a query.
-     *
-     * Some basic syntax:
-     *  - queries starting with '/' are starting at the root node
-     *  - use '*' to search all child nodes in the path
-     *  - if you search with absolute paths, don't forget to use the root node in the path.
-     *  - to search for certain attributes on nodes use [\@property0='value'] or [\@property0] to
-     * check the existence. Keep in mind that attributes search method will include parent (root)
-     * node in the elements list if search value match. In this case parent node will be the first
-     * element in the list.
-     *  - attributes can be concatenated to make them behave like an AND:
-     * [\@property0][\@property1='value']
-     *  - recursive search from root starts with '//nodes_to_search'. The whole tree is being
-     * searched.
-     *  - recursive search from current node starts with './/nodes_to_search'. The whole subtree is
-     * being searched.
-     *  - use 'and' or 'or' to connect multiple properties logically (USE ONLY ONE OPERATOR!)
-     *
-     * Here are some examples of search queries.
-     *  - /root/path/to/node                :absolute path to nodes
-     *  - path/to/node                      :search starting on current node. Same as above, if
-     * searched in root node.
-     *  - /root/node/*                      :find all children of all 'node' nodes
-     *  - *                                 :find all children of current node
-     *  - /root/node[\@prop='2']/*        :find all children of 'node' nodes with matching attribute
-     *
-     *  - //node                            :finds all 'node' nodes in the tree (recursive search)
-     *  - .//node                           :recursive search starting from current node
-     *  - //*[\@prop='2']                 :find all nodes in the tree with matching attributes
-     *  - /root/path/to[\@prop='2']//node :find all 'node' nodes in the subtree of the sub paths
-     * '/root/path/to'
-     *
-     *  - child/*[\@prop1='2']            :find all nodes in 'child' nodes with matching attributes
-     *
-     *  - *[\@prop1='3' and \@prop2='4']     :logical AND comparison for attributes
-     *
-     * @param[in] query The query string
-     * @param[out] element_ptr This will point to the found element
-     * @retval @c false if no matching node is found or the query is invalid, @c true otherwise
-     */
+    /// Finds a node based on a query.
+    ///
+    /// Some basic syntax:
+    ///  - queries starting with '/' are starting at the root node
+    ///  - use '*' to search all child nodes in the path
+    ///  - if you search with absolute paths, don't forget to use the root node in the path.
+    ///  - to search for certain attributes on nodes use [\@property0='value'] or [\@property0] to
+    /// check the existence. Keep in mind that attributes search method will include parent (root)
+    /// node in the elements list if search value match. In this case parent node will be the first
+    /// element in the list.
+    ///  - attributes can be concatenated to make them behave like an AND:
+    /// [\@property0][\@property1='value']
+    ///  - recursive search from root starts with '//nodes_to_search'. The whole tree is being
+    /// searched.
+    ///  - recursive search from current node starts with './/nodes_to_search'. The whole subtree is
+    /// being searched.
+    ///  - use 'and' or 'or' to connect multiple properties logically (USE ONLY ONE OPERATOR!)
+    ///
+    /// Here are some examples of search queries.
+    ///  - /root/path/to/node                :absolute path to nodes
+    ///  - path/to/node                      :search starting on current node. Same as above, if
+    /// searched in root node.
+    ///  - /root/node/*                      :find all children of all 'node' nodes
+    ///  - *                                 :find all children of current node
+    ///  - /root/node[\@prop='2']/*        :find all children of 'node' nodes with matching attribute
+    ///
+    ///  - //node                            :finds all 'node' nodes in the tree (recursive search)
+    ///  - .//node                           :recursive search starting from current node
+    ///  - //*[\@prop='2']                 :find all nodes in the tree with matching attributes
+    ///  - /root/path/to[\@prop='2']//node :find all 'node' nodes in the subtree of the sub paths
+    /// '/root/path/to'
+    ///
+    ///  - child/*[\@prop1='2']            :find all nodes in 'child' nodes with matching attributes
+    ///
+    ///  - *[\@prop1='3' and \@prop2='4']     :logical AND comparison for attributes
+    ///
+    /// @param[in] query The query string
+    /// @param[out] element_ptr This will point to the found element
+    /// @retval @c false if no matching node is found or the query is invalid, @c true otherwise
     bool findNode(const std::string& query, DOMElement& element_ptr) const;
 
     /**

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -5,6 +5,21 @@ For upcoming features and known issues see the bottom of this file.
 
 The format is based on [Keep a Changelog][] and this project adheres to [Semantic Versioning][].
 
+## [5.6.1][] - 2020-02-12 ##
+### Changes ###
+- [ODAUTIL-163] -
+  Extend Jenkinsfile for cross platform build of QNX target on Windows host
+
+### Fixes ###
+- [ODAUTIL-105] -
+  [Result] Warning "unreferenced formal parameter" arises when including result_type_impl.h
+- [ODAUTIL-157] - 
+  \[BuildSystem\] Language standard C++11 is not propagated
+- [ODAUTIL-168] -
+  \[Result\] Macros cannot be used with a closing semicolon without compiler warning
+- [ODAUTIL-169] -
+  Function findNode of dom.h raises `-Werror=comment` warning on gcc
+
 ## [5.6.0] - 2019-09-06 ##
 - initial commit for github
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.0)   #minimum for generated find scripts
 project(a_util_tests)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)   # we want standard compliant code without compiler extensions
 
 # Generator expressions take 0 as FALSE/OFF and 1 as TRUE/ON
 set(a_util_cmake_enable_integrated_tests 0 CACHE BOOL "" FORCE)

--- a/test/function/CMakeLists.txt
+++ b/test/function/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wno-unknown-pragmas -Wno-reorder -Wextra -pedantic)
+endif()
+
 ##get all tests listed inside ***_test_projects.cmake files (as cmake subdirectories)
 include(../../a_util/a_util_test_projects.cmake)
 include(../../3rdparty/3rdparty_test_projects.cmake)

--- a/test/private/install_complete/reference.yaml
+++ b/test/private/install_complete/reference.yaml
@@ -179,10 +179,13 @@ release:
         - lib/cmake/a_util_variant/a_util_variant_targets-release.cmake
         - lib/cmake/a_util_xml/a_util_xml_targets-release.cmake
 
-linux_debug:
+linux_and_qnx_debug:
     conditions:
-        lagd:
+        lagd_linux:
             os: Linux
+            build_type: Debug
+        lagd_neutrino:
+            os: Neutrino
             build_type: Debug
     files:
         - lib/liba_util_concurrencyd.a
@@ -200,10 +203,13 @@ linux_debug:
         - lib/liba_util_xmld.a
         
 
-linux_release:
+linux_and_qnx_release:
     conditions:
-        lagd:
+        lagd_linux:
             os: Linux
+            build_type: Release
+        lagd_neutrino:
+            os: Neutrino
             build_type: Release
     files:
         - lib/liba_util_concurrency.a


### PR DESCRIPTION
Prepares release 5.6.1
* [Result] Warning "unreferenced formal parameter" arises when including result_type_impl.h  
* [BuildSystem] Language standard C++11 is not propagated  
* [Result] Macros cannot be used with a closing semicolon without compiler warning  
* Function findNode of dom.h raises -Werror=comment warning on gcc